### PR TITLE
Localize to Polish

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ module.exports = withPWA({
   reactStrictMode: true,
   productionBrowserSourceMaps: true,
   i18n: {
-    locales: ['de', 'en', 'fr', 'es'],
+    locales: ['de', 'en', 'fr', 'es', 'pl'],
     defaultLocale: 'en',
   },
   async rewrites() {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -52,6 +52,7 @@
     "german": "Deutsch",
     "spanish": "Spanisch",
     "french": "Französisch",
+    "polish": "Polnisch",
     "cursed": "Überraschung",
     "memeculture": "Hoch lebe die Meme-Kultur!"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,6 +52,7 @@
     "german": "German",
     "spanish": "Spanish",
     "french": "French",
+    "polish": "Polish",
     "cursed": "Cursed",
     "memeculture": "Celebrating meme-culture"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -52,6 +52,7 @@
     "german": "Alemán",
     "spanish": "Español",
     "french": "Francés",
+    "polish": "Polaco",
     "cursed": "Sorpresa",
     "memeculture": "¡Viva la cultura del meme!"
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -52,6 +52,7 @@
     "german": "Allemand",
     "spanish": "Espagnol",
     "french": "Français",
+    "polish": "Polonais",
     "cursed": "Surprise",
     "memeculture": "Vive la culture des memes !"
   },

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -15,7 +15,7 @@
     "vegan": "Wegańskie",
     "vegetarian": "Wegetariańskie",
     "palmoil": "Olej palmowy",
-    "palmoil_desc": "Olej palmowy jest ekstremalnie szkodliwy dla planety. Stanowi główną przyczynę wylesiania wielu najbardziej różnorodnych biologicznie lasów, niszcząc przy tym naturalne siedliska już zagrożonych gatunków zwierząt. Z tego powodu odradzamy kupowanie produktów zawierających olej palmowy. Niestety, wciąż dostępne jest wiele produktów, które go zawierają.",
+    "palmoil_desc": "Olej palmowy jest ekstremalnie szkodliwy dla planety. Stanowi główną przyczynę wylesiania wielu najbardziej różnorodnych biologicznie lasów, niszcząc przy tym naturalne siedliska już zagrożonych gatunków zwierząt. Z tego powodu odradzamy kupowanie produktów zawierających olej palmowy. Niestety, wciąż dostępnych jest wiele produktów, które go zawierają.",
     "crueltyfree": "Wolne od okrucieństwa",
     "nutriscore_desc": "Nutriscore opisuje profil odżywczy produktu w formie sygnalizacji świetlnej. Nutriscore nie jest jednak uważany za dokładny i nie powinien być wykorzystywany jako punkt odniesienia. Więcej informacji na temat Nutriscore znajdziesz na {Algorithmwatch} (po angielsku).",
     "grades_desc": "Dezorientują Cię te wszystkie etykiety wegańskice/przyjazne dla środowiska/organiczne?<br/>Już nie będziesz mieć problemów dzięki prostemu do zrozumienia systemowi VeganCheck Grades! VeganCheck Grades to system ocen produktów wegańskich, który przydziela produktom jedną z sześciu ocen (od A+ do 'Nie kwalifikuje się').<br />Jeżeli chcesz dowiedzieć się więcej o VeganCheck Grades lub poprosić o ocenę produktu, możesz to zrobić na {Grades}!",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1,0 +1,101 @@
+{
+  "Nav": {
+    "title": "Czy to wegańskie? – Vegan Check",
+    "description": "Masz wątpliwości czy produkt jest na pewno wegański? Za pomocą VeganCheck.me możesz zeskanować kod kreskowy produktu w trakcie zakupów i sprawdzić czy jest on wegański czy nie - a to wszystko bez natłoku zbędnych informacji. Wypróbuj teraz!",
+    "home": "Strona główna",
+    "ingredientcheck": "Sprawdź składnik",
+    "more": "Więcej"
+  },
+  "Footer": {
+    "credit": "Zbudowane z {heart} przez {philipLink} i {jokeLink}"
+  },
+  "Check": {
+    "enterbarcode": "Wprowadź kod kreskowy",
+    "submit": "Wyślij",
+    "vegan": "Wegańskie",
+    "vegetarian": "Wegetariańskie",
+    "palmoil": "Olej palmowy",
+    "palmoil_desc": "Olej palmowy jest ekstremalnie szkodliwy dla planety. Stanowi główną przyczynę wylesiania wielu najbardziej różnorodnych biologicznie lasów, niszcząc przy tym naturalne siedliska już zagrożonych gatunków zwierząt. Z tego powodu odradzamy kupowanie produktów zawierających olej palmowy. Niestety, wciąż dostępne jest wiele produktów, które go zawierają.",
+    "crueltyfree": "Wolne od okrucieństwa",
+    "nutriscore_desc": "Nutriscore opisuje profil odżywczy produktu w formie sygnalizacji świetlnej. Nutriscore nie jest jednak uważany za dokładny i nie powinien być wykorzystywany jako punkt odniesienia. Więcej informacji na temat Nutriscore znajdziesz na {Algorithmwatch} (po angielsku).",
+    "grades_desc": "Dezorientują Cię te wszystkie etykiety wegańskice/przyjazne dla środowiska/organiczne?<br/>Już nie będziesz mieć problemów dzięki prostemu do zrozumienia systemowi VeganCheck Grades! VeganCheck Grades to system ocen produktów wegańskich, który przydziela produktom jedną z sześciu ocen (od A+ do 'Nie kwalifikuje się').<br />Jeżeli chcesz dowiedzieć się więcej o VeganCheck Grades lub poprosić o ocenę produktu, możesz to zrobić na {Grades}!",
+    "source": "Źródło danych",
+    "licenses": "Licencje",
+    "licenses_desc": "VeganCheck.me korzysta z różnych baz danych i API do zbierania informacji o produktach. Informacje są objęte następującymi licencjami:",
+    "notindb": "Ten produkt nie istnieje jeszcze w naszej bazie.",
+    "notindb_add": "Chcesz go dodać?",
+    "add_food": "Dodaj produkt żywnościowy",
+    "or": "lub",
+    "add_cosmetic": "dodaj kosmetyk",
+    "wrongbarcode": "Ten kod kreskowy jest niepoprawny.",
+    "timeout1": "To trwa dłużej niż zwykle",
+    "timeout2": "Zapytanie trwało zbyt długo. Spróbuj jeszcze raz.",
+    "share": "Udostępnij",
+    "copy": "Skopiuj",
+    "on": "na"
+  },
+  "More": {
+    "buyusacoffee": "Postaw nam kawę",
+    "followus": "Obserwuj nas",
+    "tos": "Warunki użytkowania",
+    "privacypolicy": "Polityka prywatności",
+    "apidocumentation": "Dokumentacja API",
+    "imprint": "Imprint",
+    "onceviapaypal": "Jednorazowo przez PayPal",
+    "onceviakofi": "Jednorazowo przez Ko-Fi",
+    "monthlyviagithub": "Comiesięcznie przez GitHub",
+    "redirect": "Nastąpi przekierowanie do serwisu",
+    "thissetsacookie": "Zostanie ustawione ciasteczko.",
+    "activatedarkmode": "Ustaw najpierw tryb ciemny na swoim urządzeniu!",
+    "language": "Język",
+    "english": "angielski",
+    "german": "niemiecki",
+    "spanish": "hiszpański",
+    "french": "francuski",
+    "polish": "polski",
+    "cursed": "przeklęty",
+    "memeculture": "Niech żyje kultura memów!"
+  },
+  "TOS": {
+    "englishgermanonly": "Ta strona jest dostępna tylko w języku angielskim i niemieckim.",
+    "tos": "Warunki użytkowania",
+    "tos_content": "<p><b>Use of \"VeganCheck.me\"</b></p><p>The use of the site \"VeganCheck.me\" is free of charge. The distribution of the contents or our services against payment is strictly prohibited. Automated queries are also prohibited and may only be performed using the <a href=\"https://jokenetwork.de/vegancheck-api\">API</a>.<br> We reserve the right to change, reduce, expand or disable our services at any time.</p><p><b>Processing of entered texts and numbers</b></p><p>On our website, barcodes or ingredients of a product can be entered in text fields. This is necessary to provide our service in its entirety. The data entry is completely voluntary.<br>Only barcodes or ingredients may be entered in the named text fields; the entry or transmission of personal data of any kind is strictly prohibited.</p><p>Personal data is any information that relates to an identified or identifiable living individual. Different pieces of information, which collected together can lead to the identification of a particular person, also constitute personal data.<sup><a href=\"https://ec.europa.eu/info/law/law-topic/data-protection/reform/what-personal-data_en\">?</a></sup></p><p><b>Disclaimer</b></p><p>We assume no liability for the accuracy of the product information and ingredient lists offered and for the availability of our service.</p>"
+  },
+  "Privacy": {
+    "germanonly": "Ta strona jest dostępna tylko w języku niemieckim."
+  },
+  "404": {
+    "error404": "Błąd 404.",
+    "pagedoesnotexist": "Ta strona nie istnieje.",
+    "message": "Sprawdź naszą {statuspage} albo nasz profil w sieci {mastodon} aby dowiedzieć się o aktualnych problemach.",
+    "statuspage": "stronę statusu"
+  },
+  "Fallback": {
+    "yourareoffline": "Brak połączenia z siecią.",
+    "needinternet": "Aby użyć VeganCheck.me połącz się z internetem.",
+    "tryagain": "Spróbuj ponownie"
+  },
+  "InstallPrompt": {
+    "subheading": "Czy To Wegańskie? - Vegan Check",
+    "install": "Zainstaluj VeganCheck.me",
+    "get": "Pobierz",
+    "howtoinstall": "Wybierz {share} a następnie \"Dodaj do ekranu głównego\"."
+  },
+  "ShortcutPrompt": {
+    "Shortcuts": "Skróty",
+    "openinapp": "Otwórz w aplikacji Skróty",
+    "open": "Otwórz"
+  },
+  "Ingredients": {
+    "ingredientcheck": "Weryfikator Składników Wegańskich",
+    "ingredientcheck_desc": "Sprawdź, czy składniki produktu są wegańskie! Wprowadź składniki oddzielając je przecinkiem",
+    "entercommaseperated": "Wprowadź składniki oddzielone przecinkiem",
+    "submit": "Wyślij",
+    "vegan": "Wegańskie",
+    "source": "Źródło danych",
+    "cannotbeempty": "Lista składników nie może być pusta, zawierać znaków specjalnych i musi być oddzielona przecinkiem!",
+    "licenses": "Licencje",
+    "licenses_desc": "VeganCheck.me uses different databases and APIs to gather information about a product. The information is licensed under the following licenses:",
+    "languagewarning": "Wyniki mogą być nieprawidłowe z racji błędów w tłumaczeniach lub niekompletnych informacji. Wyniki są tłumaczone przez {deepl}."
+  }
+}

--- a/src/pages/more.tsx
+++ b/src/pages/more.tsx
@@ -208,6 +208,24 @@ export default function More() {
                 <span className="price">{t("french")}</span>
               </div>
             </Link>
+            <Link
+              className="nolink"
+              href="/more"
+              locale="pl"
+              onClick={() => handleLanguageChange("pl")}
+            >
+              <div
+                className={router.locale === "pl" ? "option active" : "option"}
+              >
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  name="flexRadioDefault"
+                  checked={router.locale === "pl"}
+                />
+                <span className="price">{t("polish")}</span>
+              </div>
+            </Link>
             <span className="info" id="cookieinfo">
               {t("thissetsacookie")}
             </span>


### PR DESCRIPTION
[You called](https://veganism.social/@vegancheck/109915088244873553) and [I responded](https://masto.ai/@lukem/110264134377295841) 😃 🇵🇱 

Additional notes:

- I didn't translate TOS as I didn't see any existing translations other than English and German. Your project readme doesn't state that but I assume that's intentional as it's a legal document?

- The font used in the project renders Polish diacritic characters in a very ugly way but I left this out of scope of this PR - this problem requires additional investigation. I suspect updating webfont files to support latin-extended Unicode block may fix the problem.

- in Polish, unlike in English, we use [declension](https://en.wikipedia.org/wiki/Declension) and current localization setup makes it a bit tricky to work with. For example, with current setup I translate the phrase:

> Made with  by [Philip Brembeck](https://philipbrembeck.com/) & [FrontEndNet.work](https://frontendnet.work/)

as

> Zbudowane z ❤️ przez [Philip Brembeck](https://philipbrembeck.com/) i [FrontEndNet.work](https://frontendnet.work/)

but that doesn't sound natural as I can't modify the author's name in any way. The natural version should look like this:

> Zbudowane z ❤️ przez [Philipa Brembecka](https://philipbrembeck.com/) i [FrontEndNet.work](https://frontendnet.work/)

Same applies to sharing feature. Currently I translate

> Share on Mastodon

as

> Udostępnij na Mastodon

but it doesn't great. The correct translation should be:

> Udostępnij na Mastodonie

The alternative could also be:

> Udostępnij w sieci Mastodon

which literally means 'Share on Mastodon network', is formally correct but way too wordy.

In some cases it's possible to work around this limitation with clever use of words and grammar, but believe me, as a Polish native I can spot those shenanigans as they happen. 😸 

Please let me know if that helps. Thanks!