### PR TITLE
Tiny spelling correction in Polish localization

### DIFF
--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -56,7 +56,7 @@
     "polish": "polski",
     "cursed": "przeklęty",
     "memeculture": "Niech żyje kultura memów!",
-    "czech": "Czeski"
+    "czech": "czeski"
   },
   "TOS": {
     "englishgermanonly": "Ta strona jest dostępna tylko w języku angielskim i niemieckim.",


### PR DESCRIPTION
I know it's nitpicking and apologize for that. In Polish - unlike in many other languages - we write names of nationalities with lowercase letters and newly added Czech was the only one standing out.

Nonetheless, great to see the project in Czech. Great job @MichalBryxi!